### PR TITLE
Add docs API Edge Function

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -14,3 +14,6 @@ verify_jwt = false
 
 [functions.seed-test-data]
 verify_jwt = false
+
+[functions.api-docs]
+verify_jwt = false

--- a/supabase/functions/README.md
+++ b/supabase/functions/README.md
@@ -1,0 +1,27 @@
+# Supabase Functions
+
+## /api/v1/docs
+
+This edge function returns all knowledge documents for a workspace.
+Authentication uses a workspace API token stored in the `workspace_api_keys` table.
+
+### Request
+
+`GET /api/v1/docs`
+
+Headers:
+- `workspace-api-token: <YOUR_TOKEN>`
+
+Optional query parameters:
+- `category` – filter by document category
+- `last_updated` – ISO timestamp; returns documents updated after this date
+- `title_contains` – returns documents with titles containing this value
+
+### Example
+
+```bash
+curl -H "workspace-api-token: YOUR_TOKEN" \
+  "https://<project>.supabase.co/functions/v1/api-docs?category=marketing&title_contains=plan"
+```
+
+The response will be a JSON array of document records.

--- a/supabase/functions/api-docs.ts
+++ b/supabase/functions/api-docs.ts
@@ -1,0 +1,71 @@
+import "https://deno.land/x/xhr@0.1.0/mod.ts";
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { verifyWorkspaceApiToken } from './auth.ts';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'workspace-api-token, authorization, x-client-info, apikey, content-type',
+};
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  const token = req.headers.get('workspace-api-token');
+  if (!token) {
+    return new Response(
+      JSON.stringify({ error: 'workspace-api-token header required' }),
+      { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+
+  const userId = await verifyWorkspaceApiToken(token);
+  if (!userId) {
+    return new Response(
+      JSON.stringify({ error: 'Invalid workspace token' }),
+      { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+
+  const supabase = createClient(
+    Deno.env.get('SUPABASE_URL') ?? '',
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+  );
+
+  const url = new URL(req.url);
+  const category = url.searchParams.get('category');
+  const lastUpdated = url.searchParams.get('last_updated');
+  const titleContains = url.searchParams.get('title_contains');
+
+  let query = supabase
+    .from('knowledge_documents')
+    .select('*')
+    .eq('user_id', userId);
+
+  if (category) {
+    query = query.eq('category', category);
+  }
+
+  if (lastUpdated) {
+    query = query.gte('updated_at', lastUpdated);
+  }
+
+  if (titleContains) {
+    query = query.ilike('title', `%${titleContains}%`);
+  }
+
+  const { data, error } = await query.order('updated_at', { ascending: false });
+
+  if (error) {
+    return new Response(
+      JSON.stringify({ error: error.message }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+
+  return new Response(JSON.stringify(data), {
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+});

--- a/supabase/functions/auth.ts
+++ b/supabase/functions/auth.ts
@@ -1,0 +1,20 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const supabaseAdmin = createClient(
+  Deno.env.get('SUPABASE_URL') ?? '',
+  Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+);
+
+export async function verifyWorkspaceApiToken(token: string): Promise<string | null> {
+  const { data, error } = await supabaseAdmin
+    .from('workspace_api_keys')
+    .select('user_id')
+    .eq('api_key', token)
+    .eq('is_active', true)
+    .maybeSingle();
+
+  if (error || !data) {
+    return null;
+  }
+  return data.user_id as string;
+}


### PR DESCRIPTION
## Summary
- add new `api-docs` edge function with token auth
- include helper in `auth.ts` for verifying workspace tokens
- document new endpoint in `supabase/functions/README.md`
- update `supabase/config.toml` to register new function

## Testing
- `npm run lint` *(fails: no-explicit-any and other issues)*

------
https://chatgpt.com/codex/tasks/task_e_686d0ebdf3748323b6cd58e5bacfa645