### PR TITLE
Add flat pricing Billing page

### DIFF
--- a/src/pages/Settings/Billing.tsx
+++ b/src/pages/Settings/Billing.tsx
@@ -1,0 +1,51 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+
+const plans = [
+  {
+    name: 'Free',
+    price: '$0',
+    features: ['100 documents', 'Community support']
+  },
+  {
+    name: 'Starter',
+    price: '$19',
+    features: ['Unlimited docs', 'Custom prompts']
+  },
+  {
+    name: 'Pro',
+    price: '$49',
+    features: ['Branding', 'Analytics', 'API access']
+  }
+];
+
+export default function Billing() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold text-foreground">Billing</h1>
+        <p className="text-muted-foreground">Choose the plan that\'s right for you</p>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        {plans.map((plan) => (
+          <Card key={plan.name} className="text-center">
+            <CardHeader>
+              <CardTitle>{plan.name}</CardTitle>
+              <CardDescription className="text-4xl font-bold">{plan.price}</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ul className="space-y-2 mb-4">
+                {plan.features.map((feature) => (
+                  <li key={feature} className="flex items-center justify-center">
+                    <Badge variant="secondary" className="mr-2" />
+                    <span>{feature}</span>
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- simplify Billing page with three plan tiers

## Testing
- `npm run lint` *(fails: no-explicit-any errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686d1576bb088323a8e415fe00bf7831