### PR TITLE
Add DocumentList with search, pagination, skeleton

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "compute-cosine-similarity": "^1.1.0",
         "date-fns": "^3.6.0",
         "embla-carousel-react": "^8.3.0",
+        "fuse.js": "^7.1.0",
         "googleapis": "^150.0.1",
         "input-otp": "^1.2.4",
         "localforage": "^1.10.0",
@@ -4929,6 +4930,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
+      "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/gaxios": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "compute-cosine-similarity": "^1.1.0",
     "date-fns": "^3.6.0",
     "embla-carousel-react": "^8.3.0",
+    "fuse.js": "^7.1.0",
     "googleapis": "^150.0.1",
     "input-otp": "^1.2.4",
     "localforage": "^1.10.0",

--- a/src/components/DocumentList.tsx
+++ b/src/components/DocumentList.tsx
@@ -1,0 +1,123 @@
+import { useState, useMemo, useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import Fuse from 'fuse.js';
+import { supabase } from '@/integrations/supabase/client';
+import { useAuth } from '@/hooks/useAuth';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { DocumentCard } from '@/components/DocumentCard';
+
+function useDebounce<T>(value: T, delay = 300) {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const handle = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(handle);
+  }, [value, delay]);
+  return debounced;
+}
+
+const DOCS_PER_PAGE = 25;
+
+export const DocumentList = () => {
+  const { user } = useAuth();
+  const [search, setSearch] = useState('');
+  const [page, setPage] = useState(1);
+  const debouncedSearch = useDebounce(search);
+
+  const { data: documents, isLoading } = useQuery({
+    queryKey: ['all-documents', user?.id],
+    enabled: !!user,
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('knowledge_documents')
+        .select('*')
+        .eq('user_id', user!.id)
+        .order('drive_modified_at', { ascending: false });
+      if (error) throw new Error(error.message);
+      return data || [];
+    }
+  });
+
+  const fuse = useMemo(() => new Fuse(documents || [], { keys: ['title'], threshold: 0.3 }), [documents]);
+
+  const filtered = useMemo(() => {
+    const base = documents || [];
+    if (!debouncedSearch) return base;
+    return fuse.search(debouncedSearch).map(r => r.item);
+  }, [documents, fuse, debouncedSearch]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [debouncedSearch]);
+
+  const pageCount = Math.ceil(filtered.length / DOCS_PER_PAGE);
+  const paginated = useMemo(
+    () => filtered.slice((page - 1) * DOCS_PER_PAGE, page * DOCS_PER_PAGE),
+    [filtered, page]
+  );
+
+  const getCategoryColor = (category: string) => {
+    const colors: Record<string, string> = {
+      prompts: 'bg-primary',
+      marketing: 'bg-accent',
+      specs: 'bg-secondary',
+      general: 'bg-muted',
+    };
+    return colors[category] || 'bg-muted';
+  };
+
+  const handleViewDocument = (doc: any) => {
+    window.open(`https://drive.google.com/file/d/${doc.google_file_id}/view`, '_blank');
+  };
+
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Skeleton key={i} className="h-40 w-full" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <Input
+        placeholder="Search documents..."
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+      />
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {paginated.map((doc) => (
+          <DocumentCard
+            key={doc.id}
+            document={doc}
+            onView={handleViewDocument}
+            onGenerateInsights={() => {}}
+            isGeneratingInsights={false}
+            getCategoryColor={getCategoryColor}
+          />
+        ))}
+      </div>
+      {pageCount > 1 && (
+        <div className="flex justify-center items-center gap-4">
+          <Button variant="outline" size="sm" onClick={() => setPage((p) => p - 1)} disabled={page === 1}>
+            Previous
+          </Button>
+          <span className="text-sm">Page {page} of {pageCount}</span>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setPage((p) => p + 1)}
+            disabled={page === pageCount}
+          >
+            Next
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DocumentList;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -9,6 +9,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { KnowledgeBasePreview } from '@/components/KnowledgeBasePreview';
 import { AIQueryInput } from '@/components/AIQueryInput';
 import { RecentDocuments } from '@/components/RecentDocuments';
+import { DocumentList } from '@/components/DocumentList';
 import { DailyFocusModule } from '@/components/DailyFocusModule';
 import { AIAssistantSidebar } from '@/components/AIAssistantSidebar';
 import { CreateKnowledgeDocumentModal } from '@/components/CreateKnowledgeDocumentModal';
@@ -125,6 +126,7 @@ const Index = () => {
           <div className="space-y-6">
             <KnowledgeBasePreview onAskQuestion={handleAskQuestion} />
             <RecentDocuments />
+            <DocumentList />
             
             {/* Quick Actions */}
             <Card>


### PR DESCRIPTION
## Summary
- add Fuse.js dependency
- create `DocumentList` with paginated search
- integrate `DocumentList` into the index page

## Testing
- `npm run lint` *(fails: 26 errors, 10 warnings)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686d16da81fc832380f074a57cabbc85