### PR TITLE
Add privacy banner footer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import KnowledgeBases from "./pages/KnowledgeBases";
 import SyncStatus from "./pages/SyncStatus";
 import Settings from "./pages/Settings";
 import NotFound from "./pages/NotFound";
+import Footer from "./layout/Footer";
 
 const queryClient = new QueryClient();
 
@@ -37,6 +38,7 @@ function AppLayout({ children }: { children: React.ReactNode }) {
             <div className="p-6">{children}</div>
           </main>
         </div>
+        <Footer />
       </div>
     </SidebarProvider>
   );

--- a/src/layout/Footer.tsx
+++ b/src/layout/Footer.tsx
@@ -1,0 +1,16 @@
+import { Link } from "react-router-dom";
+
+const Footer = () => {
+  return (
+    <footer className="bg-secondary text-secondary-foreground text-center py-1 text-sm">
+      <span className="mr-2">
+        Private by Design — Your documents stay yours. Choose where your AI runs.
+      </span>
+      <Link to="/settings#model-provider" className="underline">
+        Model Provider
+      </Link>
+    </footer>
+  );
+};
+
+export default Footer;

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -136,7 +136,7 @@ const Settings = () => {
         </Card>
 
         {/* AI Preferences */}
-        <Card>
+        <Card id="model-provider">
           <CardHeader>
             <CardTitle className="flex items-center">
               <Brain className="h-5 w-5 mr-2" />


### PR DESCRIPTION
## Summary
- add marketing footer to highlight privacy features
- show footer in app layout
- add anchor for model provider settings section

## Testing
- `npm run lint` *(fails: Unexpected any)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686d18541fd48323846bc9ffb399795d