### PR TITLE
Add offline usage banner

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,10 +3,11 @@ import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
-import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
+import { SidebarProvider } from "@/components/ui/sidebar";
 import { offlineEnabled } from "@/lib/ai";
 import { AuthProvider, useAuth } from "@/hooks/useAuth";
 import { AppSidebar } from "@/components/AppSidebar";
+import Header from "./layout/Header";
 import Index from "./pages/Index";
 import Auth from "./pages/Auth";
 import GoogleDrive from "./pages/GoogleDrive";
@@ -32,9 +33,7 @@ function AppLayout({ children }: { children: React.ReactNode }) {
         <div className="flex flex-1 w-full">
           <AppSidebar />
           <main className="flex-1">
-            <header className="h-12 flex items-center border-b bg-background px-4">
-              <SidebarTrigger />
-            </header>
+            <Header />
             <div className="p-6">{children}</div>
           </main>
         </div>

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -1,0 +1,23 @@
+import { SidebarTrigger } from '@/components/ui/sidebar';
+import { useOffline } from '@/hooks/useOffline';
+import { useUserSettings } from '@/hooks/useUserSettings';
+
+const Header = () => {
+  const { offlineEnabled } = useOffline();
+  const { modelPreference } = useUserSettings();
+
+  const showBanner = offlineEnabled && modelPreference === 'ollama';
+
+  return (
+    <header className="h-12 flex items-center border-b bg-background px-4 relative">
+      <SidebarTrigger />
+      {showBanner && (
+        <div className="absolute inset-x-0 top-full bg-yellow-300 text-yellow-900 text-center py-1 text-sm font-medium">
+          📶 You are currently using AI offline (Ollama). All processing is local.
+        </div>
+      )}
+    </header>
+  );
+};
+
+export default Header;


### PR DESCRIPTION
## Summary
- add `Header` component with offline usage banner
- use `Header` in `AppLayout`

## Testing
- `npm run lint` *(fails: Unexpected any, etc.)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686d19e02d288323bb25d01ff659285e