### PR TITLE
Add minimal FastAPI server setup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn[standard]
+langchain
+supabase
+python-dotenv
+

--- a/serve.py
+++ b/serve.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/health")
+def health_check():
+    return {"status": "OK"}
+


### PR DESCRIPTION
## Summary
- add `requirements.txt` listing FastAPI, LangChain and Supabase dependencies
- introduce `serve.py` with a `/health` route

This repo can now be deployed to Render using:
```
uvicorn serve:app --host 0.0.0.0 --port 10000
```


------
https://chatgpt.com/codex/tasks/task_e_686db95a884c8323964eab342e7849df