### PR TITLE
Add basic FastAPI server

### DIFF
--- a/serve.py
+++ b/serve.py
@@ -1,8 +1,18 @@
+import logging
+import os
+
 from fastapi import FastAPI
+
+logging.basicConfig(level=logging.INFO)
+
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+SUPABASE_URL = os.getenv("SUPABASE_URL")
+SUPABASE_KEY = os.getenv("SUPABASE_KEY")
 
 app = FastAPI()
 
-@app.get("/health")
-def health_check():
-    return {"status": "OK"}
+
+@app.get("/ping")
+async def ping():
+    return {"status": "ok"}
 


### PR DESCRIPTION
## Summary
- create ping server with FastAPI

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: ModuleNotFoundError: No module named 'agency_swarm')*

------
https://chatgpt.com/codex/tasks/task_e_686dbb9de91483238c91365c6ab182ee