### PR TITLE
refactor: split utils into focused modules

### DIFF
--- a/research-agent/utils/__init__.py
+++ b/research-agent/utils/__init__.py
@@ -1,12 +1,20 @@
-"""
-Utilities package for Deep Research Agency Tutorial.
+"""Utilities package for Deep Research Agency Tutorial.
 
 This package contains:
-- demo: Demo and UI utilities for running agencies
+- logging: Debug logging helpers
+- streaming: Streaming logic for demos
+- demo_launchers: Demo and UI utilities for running agencies
 - pdf: PDF generation utilities for research reports
 """
 
-from .demo import copilot_demo, stream_demo, run_agency_demo
+from .demo_launchers import copilot_demo, run_agency_demo, save_research_report
+from .streaming import stream_demo
 from .pdf import save_research_to_pdf
 
-__all__ = ["copilot_demo", "stream_demo", "run_agency_demo", "save_research_to_pdf"]
+__all__ = [
+    "copilot_demo",
+    "run_agency_demo",
+    "save_research_report",
+    "stream_demo",
+    "save_research_to_pdf",
+]

--- a/research-agent/utils/demo_launchers.py
+++ b/research-agent/utils/demo_launchers.py
@@ -1,0 +1,83 @@
+"""Demo launcher utilities for research agent demos."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+from typing import Callable
+
+from agency_swarm import Agency
+
+from .pdf import save_research_to_pdf
+from .streaming import stream_demo
+
+
+def copilot_demo(
+    agency: Agency, save_pdf_func: Callable[[str, str], str] | None = None
+) -> None:
+    """Launch Copilot UI demo with optional PDF saving."""
+    try:
+        from agency_swarm.ui.demos.launcher import CopilotDemoLauncher
+
+        if save_pdf_func:
+            # Wrap the existing agency with PDF saving logic
+            original_get_response = agency.get_response
+
+            def _get_response_and_save(query: str, **kwargs):
+                response = original_get_response(query, **kwargs)
+                save_pdf_func(str(response), query)
+                return response
+
+            # Monkey-patch the method for the duration of this demo
+            agency.get_response = _get_response_and_save  # type: ignore
+
+        launcher = CopilotDemoLauncher()
+        launcher.start(agency)
+    except ImportError:
+        print("❌ Copilot demo requires additional dependencies")
+        print("Install with: pip install agency-swarm[copilot]")
+
+
+def save_research_report(response, query, output_dir="reports"):
+    """Save response to PDF with error handling."""
+    try:
+        pdf_path = save_research_to_pdf(
+            research_content=str(response), query=query, output_dir=output_dir
+        )
+        print(f"\n📄 Research report saved to: {pdf_path}")
+        return pdf_path
+    except Exception as e:  # pragma: no cover - runtime guard
+        print(f"\n❌ Error saving PDF: {e}")
+        return None
+
+
+def run_agency_demo(agency: Agency) -> None:
+    """Run the agency demo, either in terminal or Copilot UI."""
+    # Get the files directory path
+    files_dir = Path("files")
+    if files_dir.exists() and files_dir.is_dir():
+        print(f"📁 Found files directory with {len(list(files_dir.glob('*')))} files")
+        # Files will be available through MCP server
+
+    # Show MCP configuration
+    mcp_url = os.getenv("MCP_SERVER_URL", "http://localhost:8001/sse")
+    print(f"📡 MCP Server URL: {mcp_url}")
+    if "ngrok" in mcp_url:
+        print("✅ Using ngrok tunnel for public access")
+    elif "localhost" in mcp_url:
+        print(
+            "⚠️  Using localhost - OK for local testing, but OpenAI API needs public URL (use ngrok)"
+        )
+
+    if len(sys.argv) > 1 and sys.argv[1] in ["--ui", "--copilot"]:
+        print("🚀 Launching Copilot UI...")
+        copilot_demo(agency, save_research_report)
+    else:
+        print("🚀 Launching Terminal Demo...")
+        asyncio.run(stream_demo(agency, save_research_report))
+
+
+__all__ = ["copilot_demo", "run_agency_demo", "save_research_report"]
+

--- a/research-agent/utils/logging.py
+++ b/research-agent/utils/logging.py
@@ -1,0 +1,70 @@
+"""Logging helpers for research agent demos.
+
+This module provides utility functions and classes used for debug logging
+and stderr filtering during streaming.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+
+
+class FilteredStderr(io.TextIOBase):
+    """A stderr wrapper that suppresses noisy tool conversion errors."""
+
+    def write(self, s: str) -> int | None:  # type: ignore[override]
+        if "Failed to convert ToolCallItem using to_input_item()" in s:
+            return None
+        return sys.__stderr__.write(s)
+
+
+# Replace stderr with the filtered version so demos stay clean
+sys.stderr = FilteredStderr()
+
+
+def print_debug(event, seen: set[str]) -> None:
+    """Enhanced debug logging to show key research events."""
+
+    event_type = getattr(event, "type", None)
+
+    # Show new event types once
+    if (
+        event_type
+        and event_type not in seen
+        and event_type != "response.output_text.delta"
+    ):
+        print(f"\n[DEBUG] Event: {event_type}")
+        seen.add(event_type)
+
+        # Show additional details for key events
+        if event_type == "raw_response_event":
+            if hasattr(event, "data") and hasattr(event.data, "item"):
+                action = getattr(event.data.item, "action", None)
+                if action and getattr(action, "type", None) == "search":
+                    query_text = getattr(action, "query", "")
+                    if query_text:
+                        print(f"[DEBUG]   → Search Query: {query_text}")
+
+        elif event_type == "handoff_call_item":
+            if hasattr(event, "raw_item"):
+                function_name = getattr(event.raw_item, "name", "Unknown")
+                print(f"[DEBUG]   → Handoff: {function_name}")
+
+    # Show agent switches
+    elif event_type == "agent_updated_stream_event" and hasattr(event, "new_agent"):
+        agent_name = event.new_agent.name
+        print(f"\n[DEBUG] 🔄 Agent Switch: {agent_name}")
+
+    # Show web searches
+    elif event_type == "raw_response_event":
+        if hasattr(event, "data") and hasattr(event.data, "item"):
+            action = getattr(event.data.item, "action", None)
+            if action and getattr(action, "type", None) == "search":
+                query_text = getattr(action, "query", "")
+                if query_text:
+                    print(f"[DEBUG] 🔍 Web Search: {query_text}")
+
+
+__all__ = ["FilteredStderr", "print_debug"]
+

--- a/research-agent/utils/streaming.py
+++ b/research-agent/utils/streaming.py
@@ -1,74 +1,20 @@
-import asyncio
-import json
-import os
-import io
-import sys
-from typing import Callable
+"""Streaming logic for research agent demos."""
+from __future__ import annotations
 
+import json
+from typing import Callable
 from agency_swarm import Agency
 
-from .pdf import save_research_to_pdf
-
-from pathlib import Path
-
-
-class FilteredStderr(io.TextIOBase):
-    def write(self, s):
-        if "Failed to convert ToolCallItem using to_input_item()" in s:
-            return  # Ignore this line
-        sys.__stderr__.write(s)
-
-sys.stderr = FilteredStderr()
-
-
-def _print_debug(event, seen):
-    """Enhanced debug logging to show key research events."""
-    event_type = getattr(event, "type", None)
-
-    # Show new event types once
-    if (
-        event_type
-        and event_type not in seen
-        and event_type != "response.output_text.delta"
-    ):
-        print(f"\n[DEBUG] Event: {event_type}")
-        seen.add(event_type)
-
-        # Show additional details for key events
-        if event_type == "raw_response_event":
-            if hasattr(event, "data") and hasattr(event.data, "item"):
-                action = getattr(event.data.item, "action", None)
-                if action and getattr(action, "type", None) == "search":
-                    query_text = getattr(action, "query", "")
-                    if query_text:
-                        print(f"[DEBUG]   → Search Query: {query_text}")
-
-        elif event_type == "handoff_call_item":
-            if hasattr(event, "raw_item"):
-                function_name = getattr(event.raw_item, "name", "Unknown")
-                print(f"[DEBUG]   → Handoff: {function_name}")
-
-    # Show agent switches
-    elif event_type == "agent_updated_stream_event" and hasattr(event, "new_agent"):
-        agent_name = event.new_agent.name
-        print(f"\n[DEBUG] 🔄 Agent Switch: {agent_name}")
-
-    # Show web searches
-    elif event_type == "raw_response_event":
-        if hasattr(event, "data") and hasattr(event.data, "item"):
-            action = getattr(event.data.item, "action", None)
-            if action and getattr(action, "type", None) == "search":
-                query_text = getattr(action, "query", "")
-                if query_text:
-                    print(f"[DEBUG] 🔍 Web Search: {query_text}")
+from .logging import print_debug
 
 
 async def stream_demo(
     agency: Agency,
     save_pdf: Callable[[str, str], str] | None = None,
     debug: bool = True,
-):
+) -> None:
     """Interactive terminal demo following Agency Swarm patterns."""
+
     print("🌟 Research Agency Demo")
     print("Ask any research question. Type 'quit' to exit.")
     print("🔍 Debug logging enabled - you'll see key events during research.\n")
@@ -89,20 +35,22 @@ async def stream_demo(
             full_text = ""
             clarifying_text = ""
             current_agent = None
-            seen_events = set()
+            seen_events: set[str] = set()
             research_completed = False
-            stream_error = None
+            stream_error: Exception | None = None
 
             # Stream the response
             try:
                 async for event in agency.get_response_stream(query):
                     if debug:
-                        _print_debug(event, seen_events)
+                        print_debug(event, seen_events)
 
                     # Track agent switches for cleaner output
-                    if getattr(
-                        event, "type", None
-                    ) == "agent_updated_stream_event" and hasattr(event, "new_agent"):
+                    if (
+                        getattr(event, "type", None)
+                        == "agent_updated_stream_event"
+                        and hasattr(event, "new_agent")
+                    ):
                         current_agent = event.new_agent.name
                         print(f"\n\n🔄 Switched to: {current_agent}")
                         print("─" * 50)
@@ -138,7 +86,7 @@ async def stream_demo(
                             f"\n❌ Error: {event.get('content', event.get('data', 'Unknown'))}"
                         )
                         break
-            except Exception as e:
+            except Exception as e:  # pragma: no cover - runtime guard
                 stream_error = e
 
             # Handle clarification questions if we have them
@@ -170,12 +118,12 @@ async def stream_demo(
                                 clarification_response
                             ):
                                 if debug:
-                                    _print_debug(event, seen_events)
+                                    print_debug(event, seen_events)
 
-                                if getattr(
-                                    event, "type", None
-                                ) == "agent_updated_stream_event" and hasattr(
-                                    event, "new_agent"
+                                if (
+                                    getattr(event, "type", None)
+                                    == "agent_updated_stream_event"
+                                    and hasattr(event, "new_agent")
                                 ):
                                     current_agent = event.new_agent.name
                                     print(f"\n\n🔄 Switched to: {current_agent}")
@@ -196,7 +144,8 @@ async def stream_demo(
                                                 research_completed = True
 
                                 elif (
-                                    getattr(event, "type", None) == "raw_response_event"
+                                    getattr(event, "type", None)
+                                    == "raw_response_event"
                                 ):
                                     if hasattr(event, "data") and hasattr(
                                         event.data, "item"
@@ -214,7 +163,7 @@ async def stream_demo(
                                                 print(
                                                     f"\n🔍 [Web Search]: {query_text}"
                                                 )
-                        except Exception as e:
+                        except Exception as e:  # pragma: no cover - runtime guard
                             stream_error = e
                 except json.JSONDecodeError:
                     # If it's not JSON, treat as regular text
@@ -240,74 +189,11 @@ async def stream_demo(
             if stream_error:
                 print(f"\n❌ Error during streaming: {stream_error}")
 
-        except KeyboardInterrupt:
+        except KeyboardInterrupt:  # pragma: no cover - user abort
             print("\n👋 Goodbye!")
             break
-        except Exception as e:
+        except Exception as e:  # pragma: no cover - runtime guard
             print(f"\n❌ Error: {e}")
             import traceback
-
             traceback.print_exc()
 
-
-def copilot_demo(agency: Agency, save_pdf_func: Callable[[str, str], str] | None = None):
-    """Launch Copilot UI demo with optional PDF saving."""
-    try:
-        from agency_swarm.ui.demos.launcher import CopilotDemoLauncher
-
-        if save_pdf_func:
-            # Wrap the existing agency with PDF saving logic
-            original_get_response = agency.get_response
-
-            def _get_response_and_save(query: str, **kwargs):
-                response = original_get_response(query, **kwargs)
-                save_pdf_func(str(response), query)
-                return response
-
-            # Monkey-patch the method for the duration of this demo
-            agency.get_response = _get_response_and_save  # type: ignore
-
-        launcher = CopilotDemoLauncher()
-        launcher.start(agency)
-    except ImportError:
-        print("❌ Copilot demo requires additional dependencies")
-        print("Install with: pip install agency-swarm[copilot]")
-
-
-def save_research_report(response, query, output_dir="reports"):
-    """Save response to PDF with error handling."""
-    try:
-        pdf_path = save_research_to_pdf(
-            research_content=str(response), query=query, output_dir=output_dir
-        )
-        print(f"\n📄 Research report saved to: {pdf_path}")
-        return pdf_path
-    except Exception as e:
-        print(f"\n❌ Error saving PDF: {e}")
-        return None
-
-
-def run_agency_demo(agency: Agency):
-    """Run the agency demo, either in terminal or Copilot UI."""
-    # Get the files directory path
-    files_dir = Path("files")
-    if files_dir.exists() and files_dir.is_dir():
-        print(f"📁 Found files directory with {len(list(files_dir.glob('*')))} files")
-        # Files will be available through MCP server
-
-    # Show MCP configuration
-    mcp_url = os.getenv("MCP_SERVER_URL", "http://localhost:8001/sse")
-    print(f"📡 MCP Server URL: {mcp_url}")
-    if "ngrok" in mcp_url:
-        print("✅ Using ngrok tunnel for public access")
-    elif "localhost" in mcp_url:
-        print(
-            "⚠️  Using localhost - OK for local testing, but OpenAI API needs public URL (use ngrok)"
-        )
-
-    if len(sys.argv) > 1 and sys.argv[1] in ["--ui", "--copilot"]:
-        print("🚀 Launching Copilot UI...")
-        copilot_demo(agency, save_research_report)
-    else:
-        print("🚀 Launching Terminal Demo...")
-        asyncio.run(stream_demo(agency, save_research_report))


### PR DESCRIPTION
## Summary
- factor logging helpers into utils/logging.py
- move stream_demo into utils/streaming.py
- isolate demo launchers in utils/demo_launchers.py and update package exports

## Testing
- `pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68ba283d0c5c8323880062dec5dee5b7