### PR TITLE
refactor: split pdf utilities

### DIFF
--- a/research-agent/utils/pdf.py
+++ b/research-agent/utils/pdf.py
@@ -1,53 +1,25 @@
-"""
-Modern PDF Generation Utilities for Deep Research Workflow
+"""Modern PDF Generation Utilities for Deep Research Workflow"""
 
-2025 Best Practices:
-- Full markdown parsing with extensions
-- Proper URL handling with numbered references
-- Image support with automatic downloading
-- Table formatting and other markdown features
-- WeasyPrint for professional PDF generation
-"""
-
-import logging
 import os
 import re
 import tempfile
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Tuple
-from urllib.parse import urlparse
 
 import markdown
-from bs4 import BeautifulSoup
-
-# Modern PDF generation imports
 from weasyprint import CSS, HTML
 
-
-class URLReference:
-    """Represents a URL reference with title and number"""
-
-    def __init__(self, url: str, title: str = "", number: int = 1):
-        self.url = url
-        self.title = title or self._extract_domain(url)
-        self.number = number
-
-    def _extract_domain(self, url: str) -> str:
-        """Extract domain name from URL"""
-        try:
-            parsed = urlparse(url)
-            return parsed.netloc.replace("www.", "") or url
-        except:
-            return url
-
-    def __str__(self):
-        return f"[{self.number}] {self.title}: {self.url}"
-
+from .pdf_utils import (
+    URLReference,
+    create_html_document,
+    enhance_html_with_bs4,
+    extract_domain,
+    get_modern_css,
+)
 
 class ModernPDFGenerator:
     """Modern PDF generator with full markdown support"""
-
     def __init__(self):
         self.url_references: Dict[str, URLReference] = {}
         self.reference_counter = 1
@@ -95,11 +67,11 @@ class ModernPDFGenerator:
         )
 
         # Create complete HTML document
-        full_html = self._create_html_document(html_content, query, references)
+        full_html = create_html_document(html_content, query, references)
 
         # Generate PDF
         html_doc = HTML(string=full_html)
-        css = CSS(string=self._get_modern_css())
+        css = CSS(string=get_modern_css())
 
         with tempfile.TemporaryDirectory() as temp_dir:
             html_doc.write_pdf(filepath, stylesheets=[css])
@@ -138,7 +110,7 @@ class ModernPDFGenerator:
         html = md.convert(processed_content)
 
         # Enhance HTML with BeautifulSoup
-        html = self._enhance_html_with_bs4(html)
+        html = enhance_html_with_bs4(html)
 
         return html, list(self.url_references.values())
 
@@ -164,7 +136,7 @@ class ModernPDFGenerator:
             if url not in self.url_references:
                 self.url_references[url] = URLReference(
                     url=url,
-                    title=link_text or self._extract_domain_from_url(url),
+                    title=link_text or extract_domain(url),
                     number=self.reference_counter,
                 )
                 self.reference_counter += 1
@@ -184,7 +156,7 @@ class ModernPDFGenerator:
             if url not in self.url_references:
                 self.url_references[url] = URLReference(
                     url=url,
-                    title=self._extract_domain_from_url(url),
+                    title=extract_domain(url),
                     number=self.reference_counter,
                 )
                 self.reference_counter += 1
@@ -195,101 +167,6 @@ class ModernPDFGenerator:
         processed = re.sub(url_pattern, replace_bare_url, processed)
 
         return processed
-
-    def _extract_domain_from_url(self, url: str) -> str:
-        """Extract domain name from URL"""
-        try:
-            if not url.startswith(("http://", "https://")):
-                url = "https://" + url
-            parsed = urlparse(url)
-            return parsed.netloc.replace("www.", "")
-        except:
-            return url
-
-    def _enhance_html_with_bs4(self, html: str) -> str:
-        """Enhance HTML with BeautifulSoup for better formatting"""
-        try:
-            soup = BeautifulSoup(html, "html.parser")
-
-            # Add classes to elements for better styling
-            for table in soup.find_all("table"):
-                table["class"] = table.get("class", []) + ["research-table"]
-            for blockquote in soup.find_all("blockquote"):
-                blockquote["class"] = blockquote.get("class", []) + ["research-quote"]
-            for pre in soup.find_all("pre"):
-                pre["class"] = pre.get("class", []) + ["research-code"]
-
-            return str(soup)
-        except Exception as e:
-            logging.warning(f"HTML enhancement failed: {e}")
-            return html
-
-    def _create_html_document(
-        self, content: str, query: str, references: List[URLReference]
-    ) -> str:
-        """Create complete HTML document with header, content, and references"""
-
-        # Create references section
-        references_html = ""
-        if references:
-            references_html = "<div class='references'><h2>References</h2><ol class='references-list'>"
-            for ref in sorted(references, key=lambda x: x.number):
-                references_html += f"<li><strong>{ref.title}</strong><br/><a href='{ref.url}'>{ref.url}</a></li>"
-            references_html += "</ol></div>"
-
-        # Generate timestamp
-        timestamp = datetime.now().strftime("%B %d, %Y at %I:%M %p")
-
-        # Create complete HTML
-        return f"""
-        <!DOCTYPE html>
-        <html lang="en">
-        <head>
-            <meta charset="UTF-8">
-            <meta name="viewport" content="width=device-width, initial-scale=1.0">
-            <title>Deep Research Report</title>
-        </head>
-        <body>
-            <div class="document">
-                <header class="document-header">
-                    <h1 class="document-title">Deep Research Report</h1>
-                    <p class="document-query"><strong>Query:</strong> {query}</p>
-                    <p class="document-timestamp">Generated on {timestamp}</p>
-                </header>
-                <main class="document-content">{content}</main>
-                {references_html}
-            </div>
-        </body>
-        </html>
-        """
-
-    def _get_modern_css(self) -> str:
-        """Get modern CSS styles for professional PDF formatting"""
-        return """
-        @page { size: A4; margin: 2cm; }
-        body { font-family: Georgia, serif; font-size: 11pt; line-height: 1.6; color: #2c3e50; }
-        .document-header { text-align: center; margin-bottom: 2cm; padding-bottom: 1cm; border-bottom: 2px solid #3498db; }
-        .document-title { font-size: 24pt; color: #2c3e50; margin-bottom: 0.5cm; }
-        .document-query { font-size: 14pt; color: #34495e; margin-bottom: 0.3cm; }
-        .document-timestamp { font-size: 12pt; color: #7f8c8d; font-style: italic; }
-        .document-content { margin-bottom: 2cm; }
-        h1, h2, h3, h4, h5, h6 { color: #2c3e50; margin-top: 1.5em; margin-bottom: 0.5em; }
-        h1 { font-size: 20pt; } h2 { font-size: 16pt; } h3 { font-size: 14pt; }
-        p { margin-bottom: 1em; text-align: justify; }
-        ul, ol { margin-bottom: 1em; padding-left: 1.5em; }
-        .research-table { width: 100%; border-collapse: collapse; margin: 1em 0; font-size: 10pt; }
-        .research-table th, .research-table td { border: 1px solid #bdc3c7; padding: 0.5em; text-align: left; }
-        .research-table th { background-color: #ecf0f1; font-weight: bold; }
-        .research-table tr:nth-child(even) { background-color: #f8f9fa; }
-        .research-quote { border-left: 4px solid #3498db; padding-left: 1em; margin: 1em 0; font-style: italic; color: #34495e; }
-        .research-code { background-color: #f8f9fa; border: 1px solid #e9ecef; border-radius: 4px; padding: 1em; font-family: monospace; font-size: 9pt; }
-        code { background-color: #f8f9fa; padding: 0.2em 0.4em; border-radius: 3px; font-family: monospace; font-size: 9pt; }
-        .references { margin-top: 2cm; padding-top: 1cm; border-top: 1px solid #bdc3c7; }
-        .references h2 { color: #2c3e50; font-size: 16pt; margin-bottom: 1em; }
-        .references-list { font-size: 10pt; line-height: 1.4; }
-        .references-list li { margin-bottom: 0.8em; padding-bottom: 0.5em; border-bottom: 1px solid #ecf0f1; }
-        .references-list a { color: #3498db; text-decoration: none; word-break: break-all; }
-        """
 
 
 # Create a single instance for use throughout the application

--- a/research-agent/utils/pdf_utils.py
+++ b/research-agent/utils/pdf_utils.py
@@ -1,0 +1,109 @@
+"""Helper utilities for PDF generation."""
+
+import logging
+from datetime import datetime
+from typing import List
+from urllib.parse import urlparse
+
+from bs4 import BeautifulSoup
+
+
+class URLReference:
+    """Represents a URL reference with title and number."""
+
+    def __init__(self, url: str, title: str = "", number: int = 1):
+        self.url = url
+        self.title = title or extract_domain(url)
+        self.number = number
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return f"[{self.number}] {self.title}: {self.url}"
+
+
+def extract_domain(url: str) -> str:
+    """Extract domain name from URL."""
+    try:
+        if not url.startswith(("http://", "https://")):
+            url = "https://" + url
+        parsed = urlparse(url)
+        return parsed.netloc.replace("www.", "") or url
+    except Exception:
+        return url
+
+
+def enhance_html_with_bs4(html: str) -> str:
+    """Enhance HTML with BeautifulSoup for better formatting."""
+    try:
+        soup = BeautifulSoup(html, "html.parser")
+        for table in soup.find_all("table"):
+            table["class"] = table.get("class", []) + ["research-table"]
+        for blockquote in soup.find_all("blockquote"):
+            blockquote["class"] = blockquote.get("class", []) + ["research-quote"]
+        for pre in soup.find_all("pre"):
+            pre["class"] = pre.get("class", []) + ["research-code"]
+        return str(soup)
+    except Exception as e:  # pragma: no cover - best effort
+        logging.warning(f"HTML enhancement failed: {e}")
+        return html
+
+
+def create_html_document(content: str, query: str, references: List[URLReference]) -> str:
+    """Create complete HTML document with header, content, and references."""
+    references_html = ""
+    if references:
+        references_html = "<div class='references'><h2>References</h2><ol class='references-list'>"
+        for ref in sorted(references, key=lambda x: x.number):
+            references_html += (
+                f"<li><strong>{ref.title}</strong><br/><a href='{ref.url}'>{ref.url}</a></li>"
+            )
+        references_html += "</ol></div>"
+    timestamp = datetime.now().strftime("%B %d, %Y at %I:%M %p")
+    return f"""
+<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+    <meta charset=\"UTF-8\">
+    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">
+    <title>Deep Research Report</title>
+</head>
+<body>
+    <div class=\"document\">
+        <header class=\"document-header\">
+            <h1 class=\"document-title\">Deep Research Report</h1>
+            <p class=\"document-query\"><strong>Query:</strong> {query}</p>
+            <p class=\"document-timestamp\">Generated on {timestamp}</p>
+        </header>
+        <main class=\"document-content\">{content}</main>
+        {references_html}
+    </div>
+</body>
+</html>
+"""
+
+
+def get_modern_css() -> str:
+    """Get modern CSS styles for professional PDF formatting."""
+    return """@page { size: A4; margin: 2cm; }
+body { font-family: Georgia, serif; font-size: 11pt; line-height: 1.6; color: #2c3e50; }
+.document-header { text-align: center; margin-bottom: 2cm; padding-bottom: 1cm; border-bottom: 2px solid #3498db; }
+.document-title { font-size: 24pt; color: #2c3e50; margin-bottom: 0.5cm; }
+.document-query { font-size: 14pt; color: #34495e; margin-bottom: 0.3cm; }
+.document-timestamp { font-size: 12pt; color: #7f8c8d; font-style: italic; }
+.document-content { margin-bottom: 2cm; }
+h1, h2, h3, h4, h5, h6 { color: #2c3e50; margin-top: 1.5em; margin-bottom: 0.5em; }
+h1 { font-size: 20pt; } h2 { font-size: 16pt; } h3 { font-size: 14pt; }
+p { margin-bottom: 1em; text-align: justify; }
+ul, ol { margin-bottom: 1em; padding-left: 1.5em; }
+.research-table { width: 100%; border-collapse: collapse; margin: 1em 0; font-size: 10pt; }
+.research-table th, .research-table td { border: 1px solid #bdc3c7; padding: 0.5em; text-align: left; }
+.research-table th { background-color: #ecf0f1; font-weight: bold; }
+.research-table tr:nth-child(even) { background-color: #f8f9fa; }
+.research-quote { border-left: 4px solid #3498db; padding-left: 1em; margin: 1em 0; font-style: italic; color: #34495e; }
+.research-code { background-color: #f8f9fa; border: 1px solid #e9ecef; border-radius: 4px; padding: 1em; font-family: monospace; font-size: 9pt; }
+code { background-color: #f8f9fa; padding: 0.2em 0.4em; border-radius: 3px; font-family: monospace; font-size: 9pt; }
+.references { margin-top: 2cm; padding-top: 1cm; border-top: 1px solid #bdc3c7; }
+.references h2 { color: #2c3e50; font-size: 16pt; margin-bottom: 1em; }
+.references-list { font-size: 10pt; line-height: 1.4; }
+.references-list li { margin-bottom: 0.8em; padding-bottom: 0.5em; border-bottom: 1px solid #ecf0f1; }
+.references-list a { color: #3498db; text-decoration: none; word-break: break-all; }
+"""


### PR DESCRIPTION
## Summary
- factor out URL reference and HTML/CSS helpers into `pdf_utils`
- streamline `ModernPDFGenerator` to use new helpers

## Testing
- `pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2a2c708c8323bf20bbad2d68b37a