### PR TITLE
refactor: extract mcp tools

### DIFF
--- a/research-agent/mcp/server.py
+++ b/research-agent/mcp/server.py
@@ -13,6 +13,7 @@ from dotenv import load_dotenv
 from fastmcp import FastMCP
 from openai import OpenAI
 from vector_utils import detect_vector_store_id
+from tools import fetch as fetch_impl, search as search_impl
 
 # Load environment variables from .env file
 load_dotenv(override=True)
@@ -41,139 +42,13 @@ def create_server():
 
     @mcp.tool()
     async def search(query: str) -> dict[str, list[dict[str, Any]]]:
-        """Search vector store for relevant documents. Returns list with id, title, text snippet."""
-        if not query or not query.strip():
-            return {"results": []}
-
-        if not openai_client:
-            logger.error("OpenAI client not initialized - API key missing")
-            raise ValueError("OpenAI API key is required for vector store search")
-
-        if not VECTOR_STORE_ID:
-            logger.error("Vector store ID not configured")
-            raise ValueError("Vector store ID is required for search")
-
-        try:
-            # Search the vector store using OpenAI API
-            logger.info(
-                f"Searching vector store {VECTOR_STORE_ID} for query: '{query}'"
-            )
-
-            response = openai_client.vector_stores.search(
-                vector_store_id=VECTOR_STORE_ID, query=query
-            )
-
-            results = []
-
-            # Process search results
-            if hasattr(response, "data") and response.data:
-                for i, item in enumerate(response.data):
-                    item_id = getattr(item, "file_id", f"vs_{i}")
-                    item_filename = getattr(item, "filename", f"Document {i + 1}")
-
-                    # Extract text content
-                    content_list = getattr(item, "content", [])
-                    text_content = ""
-                    if content_list and len(content_list) > 0:
-                        first_content = content_list[0]
-                        if hasattr(first_content, "text"):
-                            text_content = first_content.text
-                        elif isinstance(first_content, dict):
-                            text_content = first_content.get("text", "")
-
-                    if not text_content:
-                        text_content = "No content available"
-
-                    text_snippet = (
-                        text_content[:200] + "..."
-                        if len(text_content) > 200
-                        else text_content
-                    )
-
-                    result = {
-                        "id": item_id,
-                        "title": item_filename,
-                        "text": text_snippet,
-                        "url": f"https://platform.openai.com/storage/files/{item_id}",
-                    }
-
-                    results.append(result)
-
-            logger.info(f"Vector store search returned {len(results)} results")
-            return {"results": results}
-
-        except Exception as e:
-            logger.error(f"Error during vector store search: {e}")
-            # Return empty results instead of raising to prevent server crash
-            return {"results": []}
+        """Search vector store for relevant documents."""
+        return await search_impl(query, openai_client, VECTOR_STORE_ID, logger)
 
     @mcp.tool()
     async def fetch(id: str) -> dict[str, Any]:
-        """Retrieve complete document content by ID for analysis and citation."""
-        if not id:
-            raise ValueError("Document ID is required")
-
-        if not openai_client:
-            logger.error("OpenAI client not initialized - API key missing")
-            raise ValueError(
-                "OpenAI API key is required for vector store file retrieval"
-            )
-
-        if not VECTOR_STORE_ID:
-            logger.error("Vector store ID not configured")
-            raise ValueError("Vector store ID is required for file retrieval")
-
-        try:
-            logger.info(f"Fetching content from vector store for file ID: {id}")
-
-            # Fetch file content from vector store
-            content_response = openai_client.vector_stores.files.content(
-                vector_store_id=VECTOR_STORE_ID, file_id=id
-            )
-
-            # Get file metadata
-            file_info = openai_client.vector_stores.files.retrieve(
-                vector_store_id=VECTOR_STORE_ID, file_id=id
-            )
-
-            # Extract content
-            file_content = ""
-            if hasattr(content_response, "data") and content_response.data:
-                content_parts = []
-                for content_item in content_response.data:
-                    if hasattr(content_item, "text"):
-                        content_parts.append(content_item.text)
-                file_content = "\n".join(content_parts)
-            else:
-                file_content = "No content available"
-
-            filename = getattr(file_info, "filename", f"Document {id}")
-
-            result = {
-                "id": id,
-                "title": filename,
-                "text": file_content,
-                "url": f"https://platform.openai.com/storage/files/{id}",
-                "metadata": None,
-            }
-
-            # Add metadata if available from file info
-            if hasattr(file_info, "attributes") and file_info.attributes:
-                result["metadata"] = file_info.attributes
-
-            logger.info(f"Successfully fetched vector store file: {id}")
-            return result
-
-        except Exception as e:
-            logger.error(f"Error fetching vector store file {id}: {e}")
-            # Return error result instead of raising to prevent server crash
-            return {
-                "id": id,
-                "title": f"Error retrieving document {id}",
-                "text": f"Error: {str(e)}",
-                "url": f"https://platform.openai.com/storage/files/{id}",
-                "metadata": None,
-            }
+        """Retrieve complete document content by ID."""
+        return await fetch_impl(id, openai_client, VECTOR_STORE_ID, logger)
 
     return mcp
 

--- a/research-agent/mcp/tools.py
+++ b/research-agent/mcp/tools.py
@@ -1,0 +1,135 @@
+"""Tool implementations for MCP server."""
+
+import logging
+from typing import Any
+
+from openai import OpenAI
+
+
+async def search(
+    query: str, openai_client: OpenAI, vector_store_id: str, logger: logging.Logger
+) -> dict[str, list[dict[str, Any]]]:
+    """Search vector store for relevant documents. Returns list with id, title, text snippet."""
+    if not query or not query.strip():
+        return {"results": []}
+
+    if not openai_client:
+        logger.error("OpenAI client not initialized - API key missing")
+        raise ValueError("OpenAI API key is required for vector store search")
+
+    if not vector_store_id:
+        logger.error("Vector store ID not configured")
+        raise ValueError("Vector store ID is required for search")
+
+    try:
+        logger.info(
+            f"Searching vector store {vector_store_id} for query: '{query}'"
+        )
+
+        response = openai_client.vector_stores.search(
+            vector_store_id=vector_store_id, query=query
+        )
+
+        results = []
+
+        if hasattr(response, "data") and response.data:
+            for i, item in enumerate(response.data):
+                item_id = getattr(item, "file_id", f"vs_{i}")
+                item_filename = getattr(item, "filename", f"Document {i + 1}")
+
+                content_list = getattr(item, "content", [])
+                text_content = ""
+                if content_list and len(content_list) > 0:
+                    first_content = content_list[0]
+                    if hasattr(first_content, "text"):
+                        text_content = first_content.text
+                    elif isinstance(first_content, dict):
+                        text_content = first_content.get("text", "")
+
+                if not text_content:
+                    text_content = "No content available"
+
+                text_snippet = (
+                    text_content[:200] + "..."
+                    if len(text_content) > 200
+                    else text_content
+                )
+
+                result = {
+                    "id": item_id,
+                    "title": item_filename,
+                    "text": text_snippet,
+                    "url": f"https://platform.openai.com/storage/files/{item_id}",
+                }
+
+                results.append(result)
+
+        logger.info(f"Vector store search returned {len(results)} results")
+        return {"results": results}
+
+    except Exception as e:
+        logger.error(f"Error during vector store search: {e}")
+        return {"results": []}
+
+
+async def fetch(
+    id: str, openai_client: OpenAI, vector_store_id: str, logger: logging.Logger
+) -> dict[str, Any]:
+    """Retrieve complete document content by ID for analysis and citation."""
+    if not id:
+        raise ValueError("Document ID is required")
+
+    if not openai_client:
+        logger.error("OpenAI client not initialized - API key missing")
+        raise ValueError("OpenAI API key is required for vector store file retrieval")
+
+    if not vector_store_id:
+        logger.error("Vector store ID not configured")
+        raise ValueError("Vector store ID is required for file retrieval")
+
+    try:
+        logger.info(f"Fetching content from vector store for file ID: {id}")
+
+        content_response = openai_client.vector_stores.files.content(
+            vector_store_id=vector_store_id, file_id=id
+        )
+
+        file_info = openai_client.vector_stores.files.retrieve(
+            vector_store_id=vector_store_id, file_id=id
+        )
+
+        file_content = ""
+        if hasattr(content_response, "data") and content_response.data:
+            content_parts = []
+            for content_item in content_response.data:
+                if hasattr(content_item, "text"):
+                    content_parts.append(content_item.text)
+            file_content = "\n".join(content_parts)
+        else:
+            file_content = "No content available"
+
+        filename = getattr(file_info, "filename", f"Document {id}")
+
+        result = {
+            "id": id,
+            "title": filename,
+            "text": file_content,
+            "url": f"https://platform.openai.com/storage/files/{id}",
+            "metadata": None,
+        }
+
+        if hasattr(file_info, "attributes") and file_info.attributes:
+            result["metadata"] = file_info.attributes
+
+        logger.info(f"Successfully fetched vector store file: {id}")
+        return result
+
+    except Exception as e:
+        logger.error(f"Error fetching vector store file {id}: {e}")
+        return {
+            "id": id,
+            "title": f"Error retrieving document {id}",
+            "text": f"Error: {str(e)}",
+            "url": f"https://platform.openai.com/storage/files/{id}",
+            "metadata": None,
+        }


### PR DESCRIPTION
## Summary
- move MCP search and fetch implementations into dedicated tools module
- keep MCP server focused on setup and entry point

## Testing
- `python -m py_compile research-agent/mcp/server.py research-agent/mcp/tools.py`
- `pytest` *(fails: async def functions are not natively supported)*
- `python - <<'PY'
import sys, import importlib
sys.path.append('research-agent/mcp')
import server
print('server imported:', server.create_server is not None)
PY` *(fails: The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2bdcf5048323accfb2855a2da6e2