### PR TITLE
Remove unused env vars and document required configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,13 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Environment Variables
+
+The Supabase Edge Functions in this project rely on the following environment variables:
+
+- `OPENAI_API_KEY` – used to access OpenAI's API for AI features.
+- `SUPABASE_URL` – the URL of your Supabase project.
+- `SUPABASE_SERVICE_ROLE_KEY` – service role key used by server-side functions.
+
+`SUPABASE_KEY` is not used by the current codebase.

--- a/serve.py
+++ b/serve.py
@@ -1,13 +1,8 @@
 import logging
-import os
 
 from fastapi import FastAPI
 
 logging.basicConfig(level=logging.INFO)
-
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
-SUPABASE_URL = os.getenv("SUPABASE_URL")
-SUPABASE_KEY = os.getenv("SUPABASE_KEY")
 
 app = FastAPI()
 


### PR DESCRIPTION
## Summary
- remove unused OpenAI and Supabase environment variables from FastAPI service
- document necessary environment variables for Supabase Edge Functions in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext')*
- `python -m py_compile serve.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba300cdff08323a3c54a9801005220