### PR TITLE
Include user ID in AI document analysis

### DIFF
--- a/src/pages/Documents.tsx
+++ b/src/pages/Documents.tsx
@@ -74,8 +74,9 @@ const Documents = () => {
       
       // Call AI document analysis edge function
       const { data: analysisResult, error: analysisError } = await supabase.functions.invoke('ai-document-analysis', {
-        body: { 
+        body: {
           document_id: docId,
+          user_id: user!.id,
           content: doc.content || '',
           title: doc.title
         }

--- a/supabase/functions/ai-document-analysis/index.ts
+++ b/supabase/functions/ai-document-analysis/index.ts
@@ -155,7 +155,8 @@ serve(async (req) => {
         tags: analysis.suggested_tags,
         updated_at: new Date().toISOString(),
       })
-      .eq('id', document_id);
+      .eq('id', document_id)
+      .eq('user_id', user_id);
 
     if (updateError) {
       throw new Error(`Failed to update document: ${updateError.message}`);


### PR DESCRIPTION
## Summary
- Pass the authenticated user's ID to the `ai-document-analysis` edge function so requests are scoped to the current user.
- Ensure the edge function filters document updates by `user_id` to prevent cross-user modifications.

## Testing
- `npx eslint .` *(fails: Unexpected any and other lint errors)*


------
https://chatgpt.com/codex/tasks/task_e_68ba329e38ec8323a960cdde5c82b8ad