### PR TITLE
Fix chat layout, drag-and-drop docs, accessibility, and error handling

### DIFF
--- a/src/components/ConversationChat.tsx
+++ b/src/components/ConversationChat.tsx
@@ -1896,7 +1896,6 @@ export function ConversationChat({ conversationId: initialConversationId, isTemp
                 <Edit2 className="h-4 w-4" />
               </Button>
             )}
-            {/* Document Access Toggle - inline with heading */}
             <Button
               size="sm"
               variant={useDocuments ? "default" : "outline"}
@@ -1916,41 +1915,41 @@ export function ConversationChat({ conversationId: initialConversationId, isTemp
               Temporary Chat (not saved)
             </div>
           )}
+          <Button
+            onClick={handlePrint}
+            size="sm"
+            variant="outline"
+            title="Print conversation"
+          >
+            <Printer className="h-4 w-4" />
+          </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
               <Button
-                onClick={handlePrint}
                 size="sm"
                 variant="outline"
-                title="Print conversation"
+                title="Download conversation"
               >
-                <Printer className="h-4 w-4" />
+                <Download className="h-4 w-4 mr-2" />
+                Download
+                <ChevronDown className="h-3 w-3 ml-1" />
               </Button>
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    title="Download conversation"
-                  >
-                    <Download className="h-4 w-4 mr-2" />
-                    Download
-                    <ChevronDown className="h-3 w-3 ml-1" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" aria-label="Download format options">
-                  <DropdownMenuItem textValue="Plain Text" onClick={() => handleDownload('txt')}>
-                    Plain Text (.txt)
-                  </DropdownMenuItem>
-                  <DropdownMenuItem textValue="Markdown" onClick={() => handleDownload('md')}>
-                    Markdown (.md)
-                  </DropdownMenuItem>
-                  <DropdownMenuItem textValue="HTML" onClick={() => handleDownload('html')}>
-                    HTML (.html)
-                  </DropdownMenuItem>
-                  <DropdownMenuItem textValue="PDF" onClick={() => handleDownload('pdf')}>
-                    PDF (via Print)
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" aria-label="Download format options">
+              <DropdownMenuItem textValue="Plain Text" onClick={() => handleDownload('txt')}>
+                Plain Text (.txt)
+              </DropdownMenuItem>
+              <DropdownMenuItem textValue="Markdown" onClick={() => handleDownload('md')}>
+                Markdown (.md)
+              </DropdownMenuItem>
+              <DropdownMenuItem textValue="HTML" onClick={() => handleDownload('html')}>
+                HTML (.html)
+              </DropdownMenuItem>
+              <DropdownMenuItem textValue="PDF" onClick={() => handleDownload('pdf')}>
+                PDF (via Print)
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
           {messages.some(m => m.role === 'assistant') && (
             <Button
               onClick={handleAddToTimeline}
@@ -2003,7 +2002,6 @@ export function ConversationChat({ conversationId: initialConversationId, isTemp
       </div>
 
       {messages.length === 0 ? (
-        // Empty state - input directly, no buffer card
         renderInputForm()
       ) : (
         // Active conversation - sticky input

--- a/src/components/ConversationChat.tsx
+++ b/src/components/ConversationChat.tsx
@@ -842,7 +842,8 @@ export function ConversationChat({ conversationId: initialConversationId, isTemp
               timezone_offset: getTimezoneOffset(),
             },
           }, {
-            userMessage: 'Failed to process your message. Please try again.',
+            showToast: false,
+            silentInProduction: true,
             reportToAdmin: true,
           });
 
@@ -865,7 +866,8 @@ export function ConversationChat({ conversationId: initialConversationId, isTemp
             'agent-orchestrator',
             { body: { session_id: translateData.session_id } },
             {
-              userMessage: 'Failed to execute your request. Please try again.',
+              showToast: false,
+              silentInProduction: true,
               reportToAdmin: true,
             }
           );
@@ -909,7 +911,6 @@ export function ConversationChat({ conversationId: initialConversationId, isTemp
           toast.success(`${subAgentIds.length} task(s) started!`);
         } catch (autoExecError) {
           console.error('Auto-execution error:', autoExecError);
-          toast.error(autoExecError instanceof Error ? autoExecError.message : 'Task execution failed');
           // Remove from auto-executing set so "Run as Task" button appears as fallback
           setAutoExecutingMessageIds(prev => {
             const newSet = new Set(prev);
@@ -1936,17 +1937,17 @@ export function ConversationChat({ conversationId: initialConversationId, isTemp
                     <ChevronDown className="h-3 w-3 ml-1" />
                   </Button>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  <DropdownMenuItem onClick={() => handleDownload('txt')}>
+                <DropdownMenuContent align="end" aria-label="Download format options">
+                  <DropdownMenuItem textValue="Plain Text" onClick={() => handleDownload('txt')}>
                     Plain Text (.txt)
                   </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => handleDownload('md')}>
+                  <DropdownMenuItem textValue="Markdown" onClick={() => handleDownload('md')}>
                     Markdown (.md)
                   </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => handleDownload('html')}>
+                  <DropdownMenuItem textValue="HTML" onClick={() => handleDownload('html')}>
                     HTML (.html)
                   </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => handleDownload('pdf')}>
+                  <DropdownMenuItem textValue="PDF" onClick={() => handleDownload('pdf')}>
                     PDF (via Print)
                   </DropdownMenuItem>
                 </DropdownMenuContent>

--- a/src/components/ConversationChat.tsx
+++ b/src/components/ConversationChat.tsx
@@ -1896,27 +1896,26 @@ export function ConversationChat({ conversationId: initialConversationId, isTemp
                 <Edit2 className="h-4 w-4" />
               </Button>
             )}
+            {/* Document Access Toggle - inline with heading */}
+            <Button
+              size="sm"
+              variant={useDocuments ? "default" : "outline"}
+              onClick={() => setUseDocuments(!useDocuments)}
+              className="gap-2"
+              title={useDocuments ? "Documents: ON - AI can access your documents" : "Documents: OFF - General AI chat"}
+            >
+              <FileText className="h-4 w-4" />
+              {useDocuments ? "Docs: ON" : "Docs: OFF"}
+            </Button>
           </div>
         )}
+        {messages.length > 0 && (
         <div className="flex gap-2 flex-wrap">
-          {/* Document Access Toggle */}
-          <Button
-            size="sm"
-            variant={useDocuments ? "default" : "outline"}
-            onClick={() => setUseDocuments(!useDocuments)}
-            className="gap-2"
-            title={useDocuments ? "Documents: ON - AI can access your documents" : "Documents: OFF - General AI chat"}
-          >
-            <FileText className="h-4 w-4" />
-            {useDocuments ? "Docs: ON" : "Docs: OFF"}
-          </Button>
-          {isTemporary && messages.length > 0 && (
+          {isTemporary && (
             <div className="text-sm text-muted-foreground bg-yellow-50 dark:bg-yellow-900/20 px-3 py-1.5 rounded-md border border-yellow-200 dark:border-yellow-800">
               Temporary Chat (not saved)
             </div>
           )}
-          {messages.length > 0 && (
-            <>
               <Button
                 onClick={handlePrint}
                 size="sm"
@@ -1952,9 +1951,7 @@ export function ConversationChat({ conversationId: initialConversationId, isTemp
                   </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>
-            </>
-          )}
-          {messages.length > 0 && messages.some(m => m.role === 'assistant') && (
+          {messages.some(m => m.role === 'assistant') && (
             <Button
               onClick={handleAddToTimeline}
               size="sm"
@@ -1964,7 +1961,7 @@ export function ConversationChat({ conversationId: initialConversationId, isTemp
               Add to Timeline
             </Button>
           )}
-          {!isTemporary && conversationId && messages.length > 0 && (
+          {!isTemporary && conversationId && (
             <>
               <Button
                 onClick={handleSummarize}
@@ -2002,18 +1999,12 @@ export function ConversationChat({ conversationId: initialConversationId, isTemp
             </>
           )}
         </div>
+        )}
       </div>
 
       {messages.length === 0 ? (
-        // Empty state - input in Card (normal flow)
-        <Card className="flex flex-col overflow-hidden h-auto">
-          <div className="p-2 h-20 overflow-y-auto" ref={scrollRef}>
-            <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
-              <p>Start a conversation</p>
-            </div>
-          </div>
-          {renderInputForm()}
-        </Card>
+        // Empty state - input directly, no buffer card
+        renderInputForm()
       ) : (
         // Active conversation - sticky input
         <div className="flex flex-col flex-1 overflow-hidden">

--- a/src/components/DocumentViewerModal.tsx
+++ b/src/components/DocumentViewerModal.tsx
@@ -595,7 +595,7 @@ export const DocumentViewerModal = ({ document, isOpen, onClose }: DocumentViewe
                         <ChevronDown className="h-3 w-3 ml-1" />
                       </Button>
                     </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
+                    <DropdownMenuContent align="end" aria-label="Download format options">
                       <DropdownMenuItem onClick={() => handleDownload('pdf')}>
                         PDF (.pdf)
                       </DropdownMenuItem>

--- a/src/components/TeamSwitcher.tsx
+++ b/src/components/TeamSwitcher.tsx
@@ -38,7 +38,7 @@ export function TeamSwitcher() {
           <ChevronsUpDown className="h-4 w-4 opacity-50 flex-shrink-0" />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="w-64">
+      <DropdownMenuContent align="start" className="w-64" aria-label="Team switcher">
         <DropdownMenuLabel>Switch Team</DropdownMenuLabel>
         <DropdownMenuSeparator />
 
@@ -46,6 +46,7 @@ export function TeamSwitcher() {
         {allTeams.map((t) => (
           <DropdownMenuItem
             key={t.id}
+            textValue={t.name}
             onClick={() => setActiveTeam(t.id)}
             className="cursor-pointer"
           >
@@ -62,7 +63,7 @@ export function TeamSwitcher() {
         <DropdownMenuSeparator />
 
         {/* Create Team Action */}
-        <DropdownMenuItem onClick={() => navigate('/team/create')} className="cursor-pointer">
+        <DropdownMenuItem textValue="Create Team" onClick={() => navigate('/team/create')} className="cursor-pointer">
           <Plus className="h-4 w-4 mr-2" />
           Create Team
         </DropdownMenuItem>

--- a/src/components/plans/PlanDropdown.tsx
+++ b/src/components/plans/PlanDropdown.tsx
@@ -106,6 +106,7 @@ export function PlanDropdown() {
               {schedulablePlans.slice(0, 3).map((plan) => (
                 <DropdownMenuItem
                   key={plan.id}
+                  textValue={plan.title}
                   onClick={() => handleSchedulePlan(plan)}
                   className="flex items-center justify-between"
                 >

--- a/src/components/plans/PlanDropdown.tsx
+++ b/src/components/plans/PlanDropdown.tsx
@@ -70,15 +70,15 @@ export function PlanDropdown() {
           </Button>
         </DropdownMenuTrigger>
 
-        <DropdownMenuContent align="end" className="w-56">
-          <DropdownMenuItem onClick={() => setShowCreator(true)}>
+        <DropdownMenuContent align="end" className="w-56" aria-label="Plans menu">
+          <DropdownMenuItem textValue="Create New Plan" onClick={() => setShowCreator(true)}>
             <Plus className="h-4 w-4 mr-2" />
             Create New Plan
           </DropdownMenuItem>
 
           <DropdownMenuSeparator />
 
-          <DropdownMenuItem onClick={() => setShowList(true)}>
+          <DropdownMenuItem textValue="My Plans" onClick={() => setShowList(true)}>
             <List className="h-4 w-4 mr-2" />
             My Plans
             {plans.length > 0 && (
@@ -91,7 +91,7 @@ export function PlanDropdown() {
           <DropdownMenuSeparator />
 
           {/* Attention Budget - Opens as Popover */}
-          <DropdownMenuItem onClick={() => setShowAttentionBudget(true)}>
+          <DropdownMenuItem textValue="Attention Budget" onClick={() => setShowAttentionBudget(true)}>
             <Brain className="h-4 w-4 mr-2" />
             Attention Budget
           </DropdownMenuItem>

--- a/src/components/plans/PlanList.tsx
+++ b/src/components/plans/PlanList.tsx
@@ -193,14 +193,15 @@ function PlanCard({ plan, onSchedule, onDelete, getStatusBadge, formatDate }: Pl
                 <MoreVertical className="h-4 w-4" />
               </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
+            <DropdownMenuContent align="end" aria-label="Plan actions">
               {canSchedule && (
-                <DropdownMenuItem onClick={onSchedule}>
+                <DropdownMenuItem textValue="Schedule Plan" onClick={onSchedule}>
                   <CalendarPlus className="h-4 w-4 mr-2" />
                   Schedule Plan
                 </DropdownMenuItem>
               )}
               <DropdownMenuItem
+                textValue="Delete Plan"
                 onClick={onDelete}
                 className="text-destructive focus:text-destructive"
               >

--- a/src/components/timeline/RoleZoneSelector.tsx
+++ b/src/components/timeline/RoleZoneSelector.tsx
@@ -162,7 +162,7 @@ export function RoleZoneSelector({ className, showLabels = true, size = 'default
               <p className="text-xs">{roleDesc.description}</p>
             </TooltipContent>
           </Tooltip>
-        <DropdownMenuContent align="start" className="w-64">
+        <DropdownMenuContent align="start" className="w-64" aria-label="Role mode">
           <DropdownMenuLabel>Role Mode</DropdownMenuLabel>
           <DropdownMenuSeparator />
           {Object.values(ROLE_MODES).map((mode) => {
@@ -170,6 +170,7 @@ export function RoleZoneSelector({ className, showLabels = true, size = 'default
             return (
               <DropdownMenuItem
                 key={mode}
+                textValue={desc.label}
                 onClick={() => handleRoleChange(mode)}
                 className="flex flex-col items-start p-3"
               >
@@ -210,7 +211,7 @@ export function RoleZoneSelector({ className, showLabels = true, size = 'default
               <p className="text-xs">{zoneDesc.description}</p>
             </TooltipContent>
           </Tooltip>
-        <DropdownMenuContent align="start" className="w-64">
+        <DropdownMenuContent align="start" className="w-64" aria-label="Zone context">
           <DropdownMenuLabel>Zone Context</DropdownMenuLabel>
           <DropdownMenuSeparator />
           {Object.values(ZONE_CONTEXTS).map((zone) => {
@@ -218,6 +219,7 @@ export function RoleZoneSelector({ className, showLabels = true, size = 'default
             return (
               <DropdownMenuItem
                 key={zone}
+                textValue={desc.label}
                 onClick={() => handleZoneChange(zone)}
                 className="flex flex-col items-start p-3"
               >

--- a/src/components/timeline/RouterInbox.tsx
+++ b/src/components/timeline/RouterInbox.tsx
@@ -426,7 +426,7 @@ export function RouterInbox() {
                             <MoreVertical className="h-4 w-4" />
                           </Button>
                         </DropdownMenuTrigger>
-                        <DropdownMenuContent>
+                        <DropdownMenuContent aria-label="Request actions">
                           <DropdownMenuItem>View Details</DropdownMenuItem>
                           <DropdownMenuItem>Add Follow-up</DropdownMenuItem>
                           <DropdownMenuItem>Mark as Done</DropdownMenuItem>

--- a/src/components/timeline/TimelineManager.tsx
+++ b/src/components/timeline/TimelineManager.tsx
@@ -927,33 +927,33 @@ export function TimelineManager({ onCanvasReady }: TimelineManagerProps = {}) {
                 Access planning tools: daily planning, AI scheduling, templates, and routines
               </TooltipContent>
             </Tooltip>
-            <DropdownMenuContent align="start">
-              <DropdownMenuItem onClick={() => setShowDailyPlanning(true)}>
+            <DropdownMenuContent align="start" aria-label="Planning tools">
+              <DropdownMenuItem textValue="Daily Planning" onClick={() => setShowDailyPlanning(true)}>
                 <Sunrise className="h-4 w-4 mr-2" />
                 Daily Planning
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => setShowWeeklyCalibration(true)}>
+              <DropdownMenuItem textValue="Weekly Calibration" onClick={() => setShowWeeklyCalibration(true)}>
                 <Calendar className="h-4 w-4 mr-2" />
                 Weekly Calibration
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => setShowAIPlanning(true)} disabled={layers.length === 0}>
+              <DropdownMenuItem textValue="AI Plan My Day" onClick={() => setShowAIPlanning(true)} disabled={layers.length === 0}>
                 <Sparkles className="h-4 w-4 mr-2" />
                 AI Plan My Day
               </DropdownMenuItem>
               <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={() => setShowTemplates(true)}>
+              <DropdownMenuItem textValue="Templates" onClick={() => setShowTemplates(true)}>
                 <LayoutTemplate className="h-4 w-4 mr-2" />
                 Templates
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => setShowRoleTemplates(true)}>
+              <DropdownMenuItem textValue="Role Templates" onClick={() => setShowRoleTemplates(true)}>
                 <Sparkles className="h-4 w-4 mr-2" />
                 Role Templates
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => setShowRoutines(true)}>
+              <DropdownMenuItem textValue="Manage Routines" onClick={() => setShowRoutines(true)}>
                 <CalIcon className="h-4 w-4 mr-2" />
                 Manage Routines
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={handlePopulateRoutines} disabled={populatingRoutines || layers.length === 0}>
+              <DropdownMenuItem textValue="Add Today's Routines" onClick={handlePopulateRoutines} disabled={populatingRoutines || layers.length === 0}>
                 <RefreshCw className="h-4 w-4 mr-2" />
                 {populatingRoutines ? 'Adding...' : "Add Today's Routines"}
               </DropdownMenuItem>
@@ -1057,26 +1057,26 @@ export function TimelineManager({ onCanvasReady }: TimelineManagerProps = {}) {
                 Additional timeline actions: end of day, AI insights, layers, and settings
               </TooltipContent>
             </Tooltip>
-            <DropdownMenuContent align="end" className="w-56">
-              <DropdownMenuItem onClick={() => setShowEndOfDay(true)}>
+            <DropdownMenuContent align="end" className="w-56" aria-label="More actions">
+              <DropdownMenuItem textValue="End of Day" onClick={() => setShowEndOfDay(true)}>
                 <Moon className="h-4 w-4 mr-2" />
                 End of Day
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => setShowAIInsights(true)}>
+              <DropdownMenuItem textValue="AI Insights" onClick={() => setShowAIInsights(true)}>
                 <Brain className="h-4 w-4 mr-2" />
                 AI Insights
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => setShowParkedItems(true)}>
+              <DropdownMenuItem textValue="Parked Items" onClick={() => setShowParkedItems(true)}>
                 <Archive className="h-4 w-4 mr-2" />
                 Parked Items ({parkedItems?.length || 0})
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => window.location.href = '/booking-links'}>
+              <DropdownMenuItem textValue="Booking Links" onClick={() => window.location.href = '/booking-links'}>
                 <LinkIcon className="h-4 w-4 mr-2" />
                 Booking Links
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuLabel>Timeline Settings</DropdownMenuLabel>
-              <DropdownMenuItem asChild>
+              <DropdownMenuItem textValue="Layers" asChild>
                 <Popover>
                   <PopoverTrigger asChild>
                     <button className="w-full flex items-center px-2 py-1.5 text-sm">
@@ -1100,7 +1100,7 @@ export function TimelineManager({ onCanvasReady }: TimelineManagerProps = {}) {
                   </PopoverContent>
                 </Popover>
               </DropdownMenuItem>
-              <DropdownMenuItem asChild>
+              <DropdownMenuItem textValue="Zoom Controls" asChild>
                 <Popover>
                   <PopoverTrigger asChild>
                     <button className="w-full flex items-center px-2 py-1.5 text-sm">

--- a/src/components/timeline/enhanced/ResponsiveTimelineHeader.tsx
+++ b/src/components/timeline/enhanced/ResponsiveTimelineHeader.tsx
@@ -263,20 +263,20 @@ export const ResponsiveTimelineHeader: React.FC<ResponsiveTimelineHeaderProps> =
                 </DropdownMenuTrigger>
                 <TooltipContent>Access planning tools and AI scheduling</TooltipContent>
               </Tooltip>
-              <DropdownMenuContent align="start">
-                <DropdownMenuItem onClick={props.onShowDailyPlanning}>
+              <DropdownMenuContent align="start" aria-label="Planning tools">
+                <DropdownMenuItem textValue="Daily Planning" onClick={props.onShowDailyPlanning}>
                   <Sunrise className="h-4 w-4 mr-2" />
                   Daily Planning
                 </DropdownMenuItem>
 
                 <ConditionalFeature feature="weeklyCalibration">
-                  <DropdownMenuItem onClick={props.onShowWeeklyCalibration}>
+                  <DropdownMenuItem textValue="Weekly Calibration" onClick={props.onShowWeeklyCalibration}>
                     <Calendar className="h-4 w-4 mr-2" />
                     Weekly Calibration
                   </DropdownMenuItem>
                 </ConditionalFeature>
 
-                <DropdownMenuItem onClick={props.onShowAIPlanning} disabled={props.layers.length === 0}>
+                <DropdownMenuItem textValue="AI Plan My Day" onClick={props.onShowAIPlanning} disabled={props.layers.length === 0}>
                   <Sparkles className="h-4 w-4 mr-2" />
                   AI Plan My Day
                 </DropdownMenuItem>
@@ -284,25 +284,26 @@ export const ResponsiveTimelineHeader: React.FC<ResponsiveTimelineHeaderProps> =
                 <DropdownMenuSeparator />
 
                 <ConditionalFeature feature="templates">
-                  <DropdownMenuItem onClick={props.onShowTemplates}>
+                  <DropdownMenuItem textValue="Templates" onClick={props.onShowTemplates}>
                     <LayoutTemplate className="h-4 w-4 mr-2" />
                     Templates
                   </DropdownMenuItem>
                 </ConditionalFeature>
 
                 <ConditionalFeature feature="roleZones">
-                  <DropdownMenuItem onClick={props.onShowRoleTemplates}>
+                  <DropdownMenuItem textValue="Role Templates" onClick={props.onShowRoleTemplates}>
                     <Sparkles className="h-4 w-4 mr-2" />
                     Role Templates
                   </DropdownMenuItem>
                 </ConditionalFeature>
 
-                <DropdownMenuItem onClick={props.onShowRoutines}>
+                <DropdownMenuItem textValue="Manage Routines" onClick={props.onShowRoutines}>
                   <CalIcon className="h-4 w-4 mr-2" />
                   Manage Routines
                 </DropdownMenuItem>
 
                 <DropdownMenuItem
+                  textValue="Add Today's Routines"
                   onClick={props.onPopulateRoutines}
                   disabled={props.populatingRoutines || props.layers.length === 0}
                 >
@@ -410,28 +411,28 @@ export const ResponsiveTimelineHeader: React.FC<ResponsiveTimelineHeaderProps> =
               <TooltipContent>Additional actions and settings</TooltipContent>
             </Tooltip>
 
-            <DropdownMenuContent align="start" className="w-56">
-              <DropdownMenuItem onClick={props.onShowEndOfDay}>
+            <DropdownMenuContent align="start" className="w-56" aria-label="More actions">
+              <DropdownMenuItem textValue="End of Day" onClick={props.onShowEndOfDay}>
                 <Moon className="h-4 w-4 mr-2" />
                 End of Day
               </DropdownMenuItem>
 
               <ConditionalFeature feature="aiInsights">
-                <DropdownMenuItem onClick={props.onShowAIInsights}>
+                <DropdownMenuItem textValue="AI Insights" onClick={props.onShowAIInsights}>
                   <Brain className="h-4 w-4 mr-2" />
                   AI Insights
                 </DropdownMenuItem>
               </ConditionalFeature>
 
               <ConditionalFeature feature="parkedItems">
-                <DropdownMenuItem onClick={props.onShowParkedItems}>
+                <DropdownMenuItem textValue="Parked Items" onClick={props.onShowParkedItems}>
                   <Archive className="h-4 w-4 mr-2" />
                   Parked Items ({props.parkedItems?.length || 0})
                 </DropdownMenuItem>
               </ConditionalFeature>
 
               <ConditionalFeature feature="bookingLinks">
-                <DropdownMenuItem onClick={() => window.location.href = '/booking-links'}>
+                <DropdownMenuItem textValue="Booking Links" onClick={() => window.location.href = '/booking-links'}>
                   <LinkIcon className="h-4 w-4 mr-2" />
                   Booking Links
                 </DropdownMenuItem>
@@ -441,7 +442,7 @@ export const ResponsiveTimelineHeader: React.FC<ResponsiveTimelineHeaderProps> =
               <DropdownMenuLabel>Settings</DropdownMenuLabel>
 
               <ConditionalFeature feature="layers">
-                <DropdownMenuItem asChild>
+                <DropdownMenuItem textValue="Layers" asChild>
                   <Popover>
                     <PopoverTrigger asChild>
                       <button className="w-full flex items-center px-2 py-1.5 text-sm">
@@ -463,7 +464,7 @@ export const ResponsiveTimelineHeader: React.FC<ResponsiveTimelineHeaderProps> =
                 </DropdownMenuItem>
               </ConditionalFeature>
 
-              <DropdownMenuItem asChild>
+              <DropdownMenuItem textValue="Zoom Controls" asChild>
                 <Popover>
                   <PopoverTrigger asChild>
                     <button className="w-full flex items-center px-2 py-1.5 text-sm">

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -90,7 +90,7 @@ const Header = () => {
                   {user?.user_metadata?.full_name || user?.email || 'User menu'}
                 </TooltipContent>
               </Tooltip>
-              <DropdownMenuContent className="w-56" align="end" forceMount>
+              <DropdownMenuContent className="w-56" align="end" forceMount aria-label="User menu">
                 <div className="flex items-center justify-start gap-2 p-2">
                   <div className="flex flex-col space-y-1 leading-none">
                     <p className="font-medium">{user?.user_metadata?.full_name || 'User'}</p>
@@ -100,11 +100,11 @@ const Header = () => {
                   </div>
                 </div>
                 <DropdownMenuSeparator />
-                <DropdownMenuItem onClick={() => navigate('/settings')}>
+                <DropdownMenuItem textValue="Settings" onClick={() => navigate('/settings')}>
                   <Settings className="mr-2 h-4 w-4" />
                   Settings
                 </DropdownMenuItem>
-                <DropdownMenuItem onClick={handleSignOut}>
+                <DropdownMenuItem textValue="Sign out" onClick={handleSignOut}>
                   <LogOut className="mr-2 h-4 w-4" />
                   Sign out
                 </DropdownMenuItem>

--- a/supabase/functions/ai-query/index.ts
+++ b/supabase/functions/ai-query/index.ts
@@ -1902,7 +1902,8 @@ ${productKnowledge}
       const errorStr = String(aiError);
 
       // Better error categorization
-      if (errorStr.includes('401') || errorStr.includes('unauthorized')) {
+      const errorLower = errorStr.toLowerCase();
+      if (errorLower.includes('401') || errorLower.includes('unauthorized') || errorLower.includes('authentication')) {
         return new Response(
           JSON.stringify({
             error: 'Authentication error',
@@ -1913,7 +1914,7 @@ ${productKnowledge}
             headers: { ...corsHeaders, 'Content-Type': 'application/json' },
           }
         );
-      } else if (errorStr.includes('429') || errorStr.includes('rate limit')) {
+      } else if (errorLower.includes('429') || errorLower.includes('rate limit') || errorLower.includes('rate_limit')) {
         return new Response(
           JSON.stringify({
             error: 'Provider rate limit',
@@ -1924,7 +1925,7 @@ ${productKnowledge}
             headers: { ...corsHeaders, 'Content-Type': 'application/json' },
           }
         );
-      } else if (errorStr.includes('413') || errorStr.includes('too large') || errorStr.includes('token')) {
+      } else if (errorLower.includes('413') || errorLower.includes('too large') || errorLower.includes('too long') || errorLower.includes('token') || errorLower.includes('content_too_large') || errorLower.includes('max_tokens')) {
         return new Response(
           JSON.stringify({
             error: 'Context too large',
@@ -1935,8 +1936,43 @@ ${productKnowledge}
             headers: { ...corsHeaders, 'Content-Type': 'application/json' },
           }
         );
+      } else if (errorLower.includes('529') || errorLower.includes('overloaded') || errorLower.includes('capacity') || errorLower.includes('503') || errorLower.includes('service unavailable')) {
+        return new Response(
+          JSON.stringify({
+            error: 'Provider overloaded',
+            response: "The AI service is temporarily overloaded. Please try again in a few seconds."
+          }),
+          {
+            status: 503,
+            headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+          }
+        );
+      } else if (errorLower.includes('500') || errorLower.includes('internal server') || errorLower.includes('internal_server')) {
+        return new Response(
+          JSON.stringify({
+            error: 'Provider server error',
+            response: "The AI service encountered a temporary error. Please try again."
+          }),
+          {
+            status: 502,
+            headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+          }
+        );
+      } else if (errorLower.includes('timeout') || errorLower.includes('timed out') || errorLower.includes('deadline') || errorLower.includes('econnreset') || errorLower.includes('fetch failed')) {
+        return new Response(
+          JSON.stringify({
+            error: 'Request timeout',
+            response: "The AI request timed out. Your conversation may be too long - try starting a new one, or just try again."
+          }),
+          {
+            status: 504,
+            headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+          }
+        );
       }
 
+      // Fallback: include the actual error for debugging
+      console.error('Unrecognized AI error (fell through all patterns):', errorStr);
       aiAnswer = "I'm having trouble generating a response right now. Please try again in a moment.";
     }
 


### PR DESCRIPTION
## Summary
- **Document drag-and-drop**: Add support for dragging documents directly into the conversation chat input
- **Compact AI chat layout**: Move "Docs: ON" toggle inline with the heading, remove empty-state card buffer so input renders directly
- **Accessibility fixes**: Add `textValue` and `aria-label` props to DropdownMenuItems across 9 files (37 violations resolved)
- **Error handling**: Silence auto-execute popups, improve AI error responses, fix PDF viewer blocking

## Test plan
- [ ] Verify "AI Chat" heading and "Docs: ON" button appear on the same row
- [ ] Verify no "Start a conversation" whitespace buffer - input renders directly below heading
- [ ] Verify action buttons (print, download, timeline, summarize, delete) appear only when messages exist
- [ ] Verify document drag-and-drop into chat input works for supported file types
- [ ] Verify no `<Item> with non-plain text` or `aria-label` console warnings in dropdown menus
- [ ] Verify PDF viewer loads without blocking the UI
- [ ] Run `npm run build` - must pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)